### PR TITLE
ensure coroutine generated exceptions are propagated

### DIFF
--- a/lib/reader/marcxml.py
+++ b/lib/reader/marcxml.py
@@ -166,9 +166,14 @@ def bfconvert(inputs, base=None, out=None, limit=None, rdfttl=None, config=None,
         def wrap_task():
             parser.parse(inf)
             yield
-        asyncio.Task(wrap_task())
+        task = asyncio.Task(wrap_task())
         #parse_marcxml(inf, sink)
-        loop.run_forever()
+        try:
+            loop.run_until_complete(task)
+        except Exception as ex:
+            raise ex
+        finally:
+            loop.close()
 
     if rdfttl is not None:
         logger.debug('Converting to RDF.')


### PR DESCRIPTION
Currently, when an exception occurs in a coroutine method, the event loop exits without notifiying the main process, causing it to hang. This resolves that using the second technique from https://docs.python.org/3/library/asyncio-dev.html#detect-exceptions-never-consumed.
